### PR TITLE
Improve grid gap class generation and formatting logic.

### DIFF
--- a/src/Element/GridStart.php
+++ b/src/Element/GridStart.php
@@ -98,9 +98,9 @@ class GridStart extends AbstractContentElementController
             $template->gridClasses .= ' '.$model->cp_grid_halign;
         }
 
-        $template->gridClasses .= $this->generateGapClass('mobile', $model->cp_gap_mobile);
-        $template->gridClasses .= $this->generateGapClass('tablet', $model->cp_gap_tablet);
-        $template->gridClasses .= $this->generateGapClass('desktop', $model->cp_gap_desktop);
+        $template->gridClasses .= ($model->cp_gap_mobile)  ? $this->generateGapClass('mobile', $model->cp_gap_mobile) : '';
+        $template->gridClasses .= ($model->cp_gap_tablet) ? $this->generateGapClass('tablet', $model->cp_gap_tablet) : '';
+        $template->gridClasses .= ($model->cp_gap_desktop) ? $this->generateGapClass('desktop', $model->cp_gap_desktop) : '';
 
         return $template->getResponse();
     }
@@ -121,21 +121,21 @@ class GridStart extends AbstractContentElementController
             '%s: %s %s, ',
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_mobile'][0],
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_options'][$model->cp_grid_mobile],
-            $this->formatGapOption($model->cp_gap_mobile)
+            isset($model->cp_gap_mobile) ? $this->formatGapOption($model->cp_gap_mobile) : ''
         );
 
         $configInfo .= \sprintf(
             '%s: %s %s, ',
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_tablet'][0],
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_options'][$model->cp_grid_tablet],
-            $this->formatGapOption($model->cp_gap_tablet)
+            isset($model->cp_gap_tablet) ? $this->formatGapOption($model->cp_gap_tablet) : ''
         );
 
         $configInfo .= \sprintf(
             '%s: %s %s, ',
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_desktop'][0],
             $GLOBALS['TL_LANG']['tl_content']['cp_grid_options'][$model->cp_grid_desktop],
-            $this->formatGapOption($model->cp_gap_desktop)
+            isset($model->cp_gap_desktop) ? $this->formatGapOption($model->cp_gap_desktop) : ''
         );
 
         $configInfo .= '</span>';


### PR DESCRIPTION
Added checks to ensure that grid gap classes are only generated when values are set, avoiding empty class additions. This update also includes similar conditional checks for formatting gap options, ensuring they are displayed properly only when values are available.